### PR TITLE
Tab generation performance improvement

### DIFF
--- a/+mlf/eval.m
+++ b/+mlf/eval.m
@@ -1,7 +1,5 @@
 function tab = eval(H,Z,VERBOSE)
 
-Ndigit = 32;
-
 %%% Compute combinations
 n = numel(Z);
 for ii = 1:n
@@ -28,9 +26,6 @@ for ii = 1:N
     for jj = 1:n
         tmp_z(jj) = Z{jj}(tmp{jj});
     end
-    
-    %%%% HOW TO ELEGANTLY EVALUATE H AT THESE POINTS
-    tmp_z_comma = regexprep(num2str(tmp_z,Ndigit), '\s*', ',');
-    eval(['tab(tmp{:}) = H(' tmp_z_comma ');']);
-    %%%% HOW TO ELEGANTLY EVALUATE H AT THESE POINTS
+    input_tmp_z = num2cell(tmp_z);
+    tab(tmp{:}) = H(input_tmp_z{:});
 end


### PR DESCRIPTION
Significant speedup from avoiding the costly string conversion by converting input value to a cell and using that directly.

Unclear if the limit of 32 significant digits was still needed so was removed.